### PR TITLE
feat : 타임슬롯 StoreId+date 조회시 잔여석도 같이 조회

### DIFF
--- a/src/main/java/com/popjub/storeservice/StoreServiceApplication.java
+++ b/src/main/java/com/popjub/storeservice/StoreServiceApplication.java
@@ -3,6 +3,7 @@ package com.popjub.storeservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
@@ -11,6 +12,7 @@ import com.popjub.common.exception.GlobalExceptionHandler;
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableJpaAuditing
+@EnableFeignClients
 @Import(GlobalExceptionHandler.class)
 public class StoreServiceApplication {
 

--- a/src/main/java/com/popjub/storeservice/application/dto/result/GetRemainingResult.java
+++ b/src/main/java/com/popjub/storeservice/application/dto/result/GetRemainingResult.java
@@ -1,0 +1,29 @@
+package com.popjub.storeservice.application.dto.result;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import com.popjub.storeservice.domain.entity.TimeSlot;
+
+public record GetRemainingResult(
+	String storeName,
+	LocalDate date,
+	String status,
+	LocalTime startTime,
+	LocalTime endTime,
+	Integer capacity,
+	Integer remaining
+) {
+	public static GetRemainingResult from(TimeSlot timeSlot, Integer remaining){
+		LocalTime endTime = timeSlot.getStartTime().plusMinutes(timeSlot.getInterval());
+		return new GetRemainingResult(
+			timeSlot.getStore().getName(),
+			timeSlot.getDate(),
+			timeSlot.getStatus().name(),
+			timeSlot.getStartTime(),
+			endTime,
+			timeSlot.getCapacity(),
+			remaining
+		);
+	}
+}

--- a/src/main/java/com/popjub/storeservice/application/port/ReservationServicePort.java
+++ b/src/main/java/com/popjub/storeservice/application/port/ReservationServicePort.java
@@ -1,0 +1,9 @@
+package com.popjub.storeservice.application.port;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public interface ReservationServicePort {
+	Map<UUID, Integer> getCapacities(List<UUID> timeslotIds);
+}

--- a/src/main/java/com/popjub/storeservice/application/service/TimeSlotService.java
+++ b/src/main/java/com/popjub/storeservice/application/service/TimeSlotService.java
@@ -2,6 +2,7 @@ package com.popjub.storeservice.application.service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -12,9 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.popjub.storeservice.application.dto.command.CreateTimeSlotCommand;
 import com.popjub.storeservice.application.dto.command.UpdateTimeSlotCommand;
 import com.popjub.storeservice.application.dto.result.CreateTimeSlotResult;
+import com.popjub.storeservice.application.dto.result.GetRemainingResult;
 import com.popjub.storeservice.application.dto.result.SearchTimeSlotInternalResult;
 import com.popjub.storeservice.application.dto.result.SearchTimeSlotResult;
 import com.popjub.storeservice.application.dto.result.UpdateTimeSlotResult;
+import com.popjub.storeservice.application.port.ReservationServicePort;
 import com.popjub.storeservice.application.validation.StoreValidator;
 import com.popjub.storeservice.application.validation.TimeSlotValidator;
 import com.popjub.storeservice.domain.entity.Store;
@@ -38,6 +41,7 @@ public class TimeSlotService {
 	private final StoreRepository storeRepository;
 	private final TimeSlotValidator timeSlotValidator;
 	private final StoreValidator storeValidator;
+	private final ReservationServicePort reservationServicePort;
 
 	@Transactional
 	public CreateTimeSlotResult createTimeslots(UUID storeId, CreateTimeSlotCommand command, Long currentUserId, List<String> role) {
@@ -68,9 +72,27 @@ public class TimeSlotService {
 		return timeSlotPage.map(SearchTimeSlotResult::from);
 	}
 
-	public Page<SearchTimeSlotResult> getStoreTimeSlots(UUID storeId, LocalDate date, Pageable pageable){
+	public Page<GetRemainingResult> getStoreTimeSlots(UUID storeId, LocalDate date, Pageable pageable){
 		Page<TimeSlot> timeSlotByStorePage = timeslotRepository.findAllByStore_StoreIdAndDate(storeId, date, pageable);
-		return timeSlotByStorePage.map(SearchTimeSlotResult::from);
+
+		//페이지에 있는 타임슬롯들의 ID 뽑아서 리스트로 만들기
+		List<UUID> timeslotIds = timeSlotByStorePage.stream()
+			.map(TimeSlot::getTimeslotId)
+			.toList();
+
+		//예약측으로 조회 요청
+		Map<UUID, Integer> capacities = reservationServicePort.getCapacities(timeslotIds);
+
+		//결과 매핑
+		return timeSlotByStorePage.map(
+			timeSlot -> {
+				Integer remaining = capacities.getOrDefault(
+					timeSlot.getTimeslotId(),
+					timeSlot.getCapacity()
+				);
+				return GetRemainingResult.from(timeSlot, remaining);
+			}
+		);
 	}
 
 	//스토어 타임 수정에 따른 자동 타임슬롯 재정의 메서드

--- a/src/main/java/com/popjub/storeservice/infrastructure/client/ReservationAdapter.java
+++ b/src/main/java/com/popjub/storeservice/infrastructure/client/ReservationAdapter.java
@@ -1,0 +1,28 @@
+package com.popjub.storeservice.infrastructure.client;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.popjub.storeservice.application.port.ReservationServicePort;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationAdapter implements ReservationServicePort {
+
+	private final ReservationServiceClient  reservationServiceClient;
+
+
+	@Override
+	public Map<UUID, Integer> getCapacities(List<UUID> timeslotIds) {
+		if(timeslotIds == null || timeslotIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+		return reservationServiceClient.getRemaining(timeslotIds);
+	}
+}

--- a/src/main/java/com/popjub/storeservice/infrastructure/client/ReservationServiceClient.java
+++ b/src/main/java/com/popjub/storeservice/infrastructure/client/ReservationServiceClient.java
@@ -1,0 +1,20 @@
+package com.popjub.storeservice.infrastructure.client;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Component
+@FeignClient(name = "reservation-service")
+public interface ReservationServiceClient {
+
+	@PostMapping("/internal/reservations/capacities")
+	Map<UUID, Integer> getRemaining(
+		@RequestBody List<UUID> timeslotIds
+	);
+}

--- a/src/main/java/com/popjub/storeservice/presentation/controller/TimeSlotController.java
+++ b/src/main/java/com/popjub/storeservice/presentation/controller/TimeSlotController.java
@@ -28,12 +28,14 @@ import com.popjub.common.response.PageResponse;
 import com.popjub.storeservice.application.dto.command.CreateTimeSlotCommand;
 import com.popjub.storeservice.application.dto.command.UpdateTimeSlotCommand;
 import com.popjub.storeservice.application.dto.result.CreateTimeSlotResult;
+import com.popjub.storeservice.application.dto.result.GetRemainingResult;
 import com.popjub.storeservice.application.dto.result.SearchTimeSlotResult;
 import com.popjub.storeservice.application.dto.result.UpdateTimeSlotResult;
 import com.popjub.storeservice.application.service.TimeSlotService;
 import com.popjub.storeservice.presentation.dto.request.CreateTimeSlotRequest;
 import com.popjub.storeservice.presentation.dto.request.UpdateTimeSlotRequest;
 import com.popjub.storeservice.presentation.dto.response.CreateTimeSlotResponse;
+import com.popjub.storeservice.presentation.dto.response.GetRemainingResponse;
 import com.popjub.storeservice.presentation.dto.response.SearchTimeSlotResponse;
 import com.popjub.storeservice.presentation.dto.response.UpdateTimeSlotResponse;
 
@@ -92,7 +94,7 @@ public class TimeSlotController {
 
 
 	@GetMapping("/{storeId}/timeslots")
-	public ApiResponse<PageResponse<SearchTimeSlotResponse>> getStoreTimeSlotsByDate(
+	public ApiResponse<PageResponse<GetRemainingResponse>> getStoreTimeSlotsByDate(
 		@PathVariable UUID storeId,
 		@RequestParam LocalDate date,
 		@PageableDefault(size = 10) Pageable pageable
@@ -105,9 +107,9 @@ public class TimeSlotController {
 				Sort.Order.asc("startTime")
 			)
 		);
-		Page<SearchTimeSlotResult> result =
+		Page<GetRemainingResult> result =
 			timeSlotService.getStoreTimeSlots(storeId, date, sortedPageable);
-		Page<SearchTimeSlotResponse> responsePage = result.map(SearchTimeSlotResponse::from);
+		Page<GetRemainingResponse> responsePage = result.map(GetRemainingResponse::from);
 		return ApiResponse.of(SuccessCode.OK, PageResponse.from(responsePage));
 	}
 

--- a/src/main/java/com/popjub/storeservice/presentation/dto/response/GetRemainingResponse.java
+++ b/src/main/java/com/popjub/storeservice/presentation/dto/response/GetRemainingResponse.java
@@ -1,0 +1,28 @@
+package com.popjub.storeservice.presentation.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import com.popjub.storeservice.application.dto.result.GetRemainingResult;
+
+public record GetRemainingResponse(
+	String storeName,
+	LocalDate date,
+	String status,
+	LocalTime startTime,
+	LocalTime endTime,
+	Integer capacity,
+	Integer remaining
+) {
+	public static GetRemainingResponse from(GetRemainingResult result){
+		return new GetRemainingResponse(
+			result.storeName(),
+			result.date(),
+			result.status(),
+			result.startTime(),
+			result.endTime(),
+			result.capacity(),
+			result.remaining()
+		);
+	}
+}


### PR DESCRIPTION
 타임슬롯 StoreId+date 조회시 잔여석도 같이 조회

## ❗️ 관련 이슈 링크
- #42 

## 📝 작업 내용 상세 작성
- 타임슬롯 날짜와 storeId 기반 일별 타임슬롯 조회시 잔여석도 같이 표기

## 🚀 PR 타입
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더 수정, 삭제

## 👀 참고 사항
<img width="371" height="283" alt="{B997A2E0-2D81-46C6-B3C9-AB12791C4358}" src="https://github.com/user-attachments/assets/a03fd9c0-a119-44d1-8364-2393a0ae4c90" />

<img width="397" height="259" alt="{861FE14B-1E9E-47F0-BA0B-78E00C269C6A}" src="https://github.com/user-attachments/assets/0caff434-b61d-4909-b3eb-8d4926407506" />
잔여석 증가, 감소 테스트
