### PR TITLE
feat : 스케쥴러를 돌려 타임슬롯 종료시 자동으로 CLOSED

### DIFF
--- a/src/main/java/com/popjub/storeservice/StoreServiceApplication.java
+++ b/src/main/java/com/popjub/storeservice/StoreServiceApplication.java
@@ -6,6 +6,7 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import com.popjub.common.exception.GlobalExceptionHandler;
 
@@ -13,6 +14,7 @@ import com.popjub.common.exception.GlobalExceptionHandler;
 @EnableDiscoveryClient
 @EnableJpaAuditing
 @EnableFeignClients
+@EnableScheduling
 @Import(GlobalExceptionHandler.class)
 public class StoreServiceApplication {
 

--- a/src/main/java/com/popjub/storeservice/application/scheduler/TimeSlotCloseScheduler.java
+++ b/src/main/java/com/popjub/storeservice/application/scheduler/TimeSlotCloseScheduler.java
@@ -1,0 +1,35 @@
+package com.popjub.storeservice.application.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.popjub.storeservice.domain.repository.TimeSlotRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TimeSlotCloseScheduler {
+
+	private final TimeSlotRepository timeSlotRepository;
+
+	@Transactional
+	@Scheduled(cron = "0 */10 8-22 * * *" , zone = "Asia/Seoul")
+	// @Scheduled(fixedDelay = 10_000, initialDelay = 1_000) //테스트용
+	public void closeTimeSlot() {
+		LocalDateTime now = LocalDateTime.now();
+		List<UUID> closedIds = timeSlotRepository.closedUpdate(now);
+
+		log.info("[TimeSlotCloseScheduler] triggered at={}, closedCount={}", now, closedIds.size());
+		if (!closedIds.isEmpty()) {
+			log.debug("[TimeSlotCloseScheduler] closedIds(sample)={}", closedIds.stream().limit(5).toList());
+		}
+	}
+}

--- a/src/main/java/com/popjub/storeservice/domain/repository/TimeSlotRepository.java
+++ b/src/main/java/com/popjub/storeservice/domain/repository/TimeSlotRepository.java
@@ -1,6 +1,7 @@
 package com.popjub.storeservice.domain.repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -25,4 +26,6 @@ public interface TimeSlotRepository {
 	void deleteAllByStoreAndDate(Store store, LocalDate date);
 
 	List<TimeSlot> findAllByStore(Store store);
+
+	List<UUID> closedUpdate(LocalDateTime now);
 }

--- a/src/main/java/com/popjub/storeservice/infrastructure/repository/TimeSlotJpaRepository.java
+++ b/src/main/java/com/popjub/storeservice/infrastructure/repository/TimeSlotJpaRepository.java
@@ -1,12 +1,16 @@
 package com.popjub.storeservice.infrastructure.repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.popjub.storeservice.domain.entity.Store;
 import com.popjub.storeservice.domain.entity.TimeSlot;
@@ -19,4 +23,15 @@ public interface TimeSlotJpaRepository extends JpaRepository<TimeSlot, UUID> {
 	void deleteAllByStoreAndDate(Store store, LocalDate date);
 
 	List<TimeSlot> findAllByStoreAndDeletedAtIsNull(Store store);
+
+	//벌크 업데이트(네이티브 쿼리 사용) + Closed된 타임슬롯 ID 반환
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query(value = """
+  with updated as(update p_timeslot t
+     set status = 'CLOSED' 			-- AVAILABLE을 대상으로 종료된 타임슬롯을 CLOSED로 변경
+   where status = 'AVAILABLE'
+     and (t.date + t.start_time + make_interval(mins => t.interval_minutes)) < :now --타임슬롯 종료 시간 계산 후 현재 시간과 비교
+  returning t.timeslot_id) select timeslot_id from updated
+""", nativeQuery = true) //JPQL이 아닌 nativeQuery
+	List<UUID> closeExpired(@Param("now") LocalDateTime now); //현재 시각 주입
 }

--- a/src/main/java/com/popjub/storeservice/infrastructure/repository/TimeSlotRepositoryImpl.java
+++ b/src/main/java/com/popjub/storeservice/infrastructure/repository/TimeSlotRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.popjub.storeservice.infrastructure.repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -53,5 +54,10 @@ public class TimeSlotRepositoryImpl implements TimeSlotRepository {
 	@Override
 	public List<TimeSlot> findAllByStore(Store store) {
 		return timeSlotJpaRepository.findAllByStoreAndDeletedAtIsNull(store);
+	}
+
+	@Override
+	public List<UUID> closedUpdate(LocalDateTime now) {
+		return timeSlotJpaRepository.closeExpired(now);
 	}
 }


### PR DESCRIPTION


## ❗️ 관련 이슈 링크
- #44 

## 📝 작업 내용 상세 작성
스케쥴러는 오전 8시부터 오후 10시까지 10분마다 돌리는걸로 일단 구현했습니다.
네이티브 쿼리로 벌크업데이트 + 종료된 타임슬롯 ID들 반환까지 구현했습니다.
## 🚀 PR 타입
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더 수정, 삭제

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.
