### PR TITLE
feat : closed된 타임슬롯 id 예약측에 전송

### DIFF
--- a/src/main/java/com/popjub/storeservice/application/event/TimeSlotCloseEvent.java
+++ b/src/main/java/com/popjub/storeservice/application/event/TimeSlotCloseEvent.java
@@ -1,0 +1,7 @@
+package com.popjub.storeservice.application.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record TimeSlotCloseEvent(List<UUID> timeslotIds) {
+}

--- a/src/main/java/com/popjub/storeservice/application/listner/TimeSlotCloseNotifier.java
+++ b/src/main/java/com/popjub/storeservice/application/listner/TimeSlotCloseNotifier.java
@@ -1,0 +1,23 @@
+package com.popjub.storeservice.application.listner;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.popjub.storeservice.application.event.TimeSlotCloseEvent;
+import com.popjub.storeservice.infrastructure.client.ReservationServiceClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TimeSlotCloseNotifier {
+
+	private final ReservationServiceClient client;
+
+	//트랜잭션이 정상적으로 COMMIT 된 이후 예약측에 데이터 전송
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void onClosed(TimeSlotCloseEvent event) {
+		client.sendClosedIds(event.timeslotIds());
+	}
+}

--- a/src/main/java/com/popjub/storeservice/application/scheduler/TimeSlotCloseScheduler.java
+++ b/src/main/java/com/popjub/storeservice/application/scheduler/TimeSlotCloseScheduler.java
@@ -1,14 +1,12 @@
 package com.popjub.storeservice.application.scheduler;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.popjub.storeservice.domain.repository.TimeSlotRepository;
+import com.popjub.storeservice.application.service.TimeSlotService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,18 +16,13 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TimeSlotCloseScheduler {
 
-	private final TimeSlotRepository timeSlotRepository;
+	private final TimeSlotService timeSlotService;
 
 	@Transactional
 	@Scheduled(cron = "0 */10 8-22 * * *" , zone = "Asia/Seoul")
-	// @Scheduled(fixedDelay = 10_000, initialDelay = 1_000) //테스트용
+	/*@Scheduled(fixedDelay = 10_000, initialDelay = 1_000) //테스트용*/
 	public void closeTimeSlot() {
-		LocalDateTime now = LocalDateTime.now();
-		List<UUID> closedIds = timeSlotRepository.closedUpdate(now);
-
-		log.info("[TimeSlotCloseScheduler] triggered at={}, closedCount={}", now, closedIds.size());
-		if (!closedIds.isEmpty()) {
-			log.debug("[TimeSlotCloseScheduler] closedIds(sample)={}", closedIds.stream().limit(5).toList());
-		}
+		timeSlotService.closeAndSend(LocalDateTime.now());
 	}
 }
+

--- a/src/main/java/com/popjub/storeservice/application/service/TimeSlotService.java
+++ b/src/main/java/com/popjub/storeservice/application/service/TimeSlotService.java
@@ -1,10 +1,12 @@
 package com.popjub.storeservice.application.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,7 @@ import com.popjub.storeservice.application.dto.result.GetRemainingResult;
 import com.popjub.storeservice.application.dto.result.SearchTimeSlotInternalResult;
 import com.popjub.storeservice.application.dto.result.SearchTimeSlotResult;
 import com.popjub.storeservice.application.dto.result.UpdateTimeSlotResult;
+import com.popjub.storeservice.application.event.TimeSlotCloseEvent;
 import com.popjub.storeservice.application.port.ReservationServicePort;
 import com.popjub.storeservice.application.validation.StoreValidator;
 import com.popjub.storeservice.application.validation.TimeSlotValidator;
@@ -42,6 +45,7 @@ public class TimeSlotService {
 	private final TimeSlotValidator timeSlotValidator;
 	private final StoreValidator storeValidator;
 	private final ReservationServicePort reservationServicePort;
+	private final ApplicationEventPublisher publisher;
 
 	@Transactional
 	public CreateTimeSlotResult createTimeslots(UUID storeId, CreateTimeSlotCommand command, Long currentUserId, List<String> role) {
@@ -158,5 +162,14 @@ public class TimeSlotService {
 			.orElseThrow(() -> new StoreCustomException(StoreErrorCode.NOT_FOUND_TIME_SLOT));
 
 		return  SearchTimeSlotInternalResult.from(timeSlot);
+	}
+
+	@Transactional
+	public void closeAndSend(LocalDateTime now){
+		List<UUID> closedIds = timeslotRepository.closedUpdate(now);
+		if(closedIds.isEmpty()){
+			return;
+		}
+		publisher.publishEvent(new TimeSlotCloseEvent(closedIds));
 	}
 }

--- a/src/main/java/com/popjub/storeservice/infrastructure/client/ReservationServiceClient.java
+++ b/src/main/java/com/popjub/storeservice/infrastructure/client/ReservationServiceClient.java
@@ -17,4 +17,8 @@ public interface ReservationServiceClient {
 	Map<UUID, Integer> getRemaining(
 		@RequestBody List<UUID> timeslotIds
 	);
+
+	@PostMapping("/internal/reservations/timeslots/closed")
+	void sendClosedIds(@RequestBody List<UUID> timeslotIds);
+
 }


### PR DESCRIPTION


## ❗️ 관련 이슈 링크
- #45 

## 📝 작업 내용 상세 작성
스케쥴러 돌려서 타임슬롯 종료 시간이 지나면 벌크업데이트로 CLOSED로 변경 후 
CLOSED된 ID 리스트를 얻음 
트랜잭션이 정상적으로 커밋되면 예약측에 ID리스트 전송
## 🚀 PR 타입
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더 수정, 삭제

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.
